### PR TITLE
Fix build by using target framework version 2.1 everywhere

### DIFF
--- a/src/RouteableTiles.CLI/RouteableTiles.CLI.csproj
+++ b/src/RouteableTiles.CLI/RouteableTiles.CLI.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
The Dockerfile and the project file for the CLI project disagree on the target framework version, causing the Docker image build to fail.