### PR TITLE
Set the CORS header for easier testing without nginx

### DIFF
--- a/src/RouteableTiles.API/Controllers/TilesController.cs
+++ b/src/RouteableTiles.API/Controllers/TilesController.cs
@@ -29,6 +29,7 @@ namespace RouteableTiles.API.Controllers
             if (data == null) return NotFound();
             
             Response.Headers[HeaderNames.CacheControl] = "public,max-age=" + 60 * 60;
+            Response.Headers[HeaderNames.AccessControlAllowOrigin] = "*";
             
             return new TileResponse()
             {


### PR DESCRIPTION
With this change, I can connect the API container directly to Planner.js for local testing and development.